### PR TITLE
Use OS path separator to replace by underscore.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function plugin(source) {
     .slice(1)
     .replace(basePath, '')
     .replace('.i18n', '')
-    .replaceAll('/', '_')}${hashSum ? `_${hashSum}` : ''}`;
+    .replaceAll(path.sep, '_')}${hashSum ? `_${hashSum}` : ''}`;
   const json = JSON.parse(source);
 
   const languages = Object.keys(json);


### PR DESCRIPTION
Using the forward slash didn't work on Windows. The files were created with an escaped namespace (ie: `apptest.json` instead of `app\test.json`) and HTTP Backend was trying to find an escaped file also (ie: `/locales/en/apptest.json` instead of `/locales/en/app/test.json`).