### PR TITLE
Don't assume user root output path.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,13 +41,8 @@ function plugin(source) {
   languages.forEach((language) => {
     const localePath = getLocalePath(language, namespace, localeFilesPattern);
 
-    fs.mkdirSync(path.dirname(this.rootContext + localePath), {
-      recursive: true,
-    });
-    fs.writeFileSync(
-      this.rootContext + localePath,
-      JSON.stringify(json[language]),
-    );
+    fs.mkdirSync(path.dirname(localePath), { recursive: true });
+    fs.writeFileSync(localePath, JSON.stringify(json[language]));
   });
 
   return `export default ${JSON.stringify(


### PR DESCRIPTION
All webpack config I am using does not assume that my path will be from the root of the workspace (or root context). As such, this one shouldn't either.

However, I have no clues if this affect the default value. I'll have to check it out tomorrow.