### PR TITLE
Change the template so that the output *.d.ts file looks better.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,11 +31,9 @@ function plugin(source) {
 
   fs.writeFileSync(
     `${this.resourcePath}.d.ts`,
-    `declare const locales = ${JSON.stringify(
-      i18nTypes,
-    )} as const;export default locales;
-    export const namespace = '${namespace}' as const;
-    `,
+    `declare const locales = ${JSON.stringify(i18nTypes)} as const;
+export default locales;
+export const namespace = '${namespace}' as const;
   );
 
   languages.forEach((language) => {
@@ -50,9 +48,8 @@ function plugin(source) {
     );
   });
 
-  return `export default ${JSON.stringify(
-    i18nTypes,
-  )};export const namespace = '${namespace}'`;
+  return `export default ${JSON.stringify(i18nTypes)};
+export const namespace = '${namespace}'`;
 }
 
 module.exports = plugin;


### PR DESCRIPTION
Quick one to change the output format of the .d.ts files.

Currently it goes like this:
```typescript
declare const locales = {"intro":"app\\app:intro"} as const;export default locales;
    export const namespace = 'app\app' as const;
    
```

With this changes, it should go like this:
```typescript
declare const locales = { intro: "app\\app:intro" } as const;
export default locales;
export const namespace = "appapp" as const;
```